### PR TITLE
publish: Drop open dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "workspaces": [ "packages/publish-plugin" ],
     "prettier": "@wonderlandengine/prettier-config",
     "scripts": {
-        "pretty": "prettier --write \"publish/**/*.mjs\""
+        "pretty": "prettier --write \"packages/**/*.mjs\""
     },
     "devDependencies": {
         "@wonderlandengine/prettier-config": "^1.0.0",

--- a/packages/publish-plugin/index.mjs
+++ b/packages/publish-plugin/index.mjs
@@ -1,6 +1,5 @@
 import {EditorPlugin, ui, tools, data, project} from '@wonderlandengine/editor-api';
 import {CloudClient} from '@wonderlandcloud/cli';
-import open from 'open';
 
 export default class PublishPlugin extends EditorPlugin {
     token = '';
@@ -60,9 +59,7 @@ export default class PublishPlugin extends EditorPlugin {
             ui.label(`Published at: ${this.publishedUrl}`);
             ui.separator();
             if (ui.button('Open')) {
-                open(`https://${this.publishedUrl}`)
-                    .then(() => {})
-                    .catch((e) => {});
+                tools.openBrowser(`https://${this.publishedUrl}`);
             }
         }
 
@@ -84,7 +81,9 @@ export default class PublishPlugin extends EditorPlugin {
         console.log(`created action token: ${action.id}`);
 
         if (!this.token || !(await this.validateAuthToken(this.token))) {
-            await open(`https://wonderlandengine.com/account/?actionId=${action.id}`);
+            tools.openBrowser(
+                `https://wonderlandengine.com/account/?actionId=${action.id}`
+            );
             const result = await api.pollActionResult();
 
             this.token = result;

--- a/packages/publish-plugin/package.json
+++ b/packages/publish-plugin/package.json
@@ -11,7 +11,6 @@
     ],
     "dependencies": {
         "@wonderlandcloud/cli": "^0.1.4",
-        "@wonderlandengine/editor-api": "^1.2.0-dev.3",
-        "open": "^10.1.0"
+        "@wonderlandengine/editor-api": "^1.2.0-dev.3"
     }
 }


### PR DESCRIPTION
Drops the `open` package in favor of the new `tools.openBrowser()`. Otherwise the bundled plugin fails to load.