### PR TITLE
publish: Bump editor-api dependency version

### DIFF
--- a/packages/publish-plugin/package.json
+++ b/packages/publish-plugin/package.json
@@ -11,6 +11,6 @@
     ],
     "dependencies": {
         "@wonderlandcloud/cli": "^0.1.4",
-        "@wonderlandengine/editor-api": "^1.2.0-dev.3"
+        "@wonderlandengine/editor-api": "^1.2.3-dev.1"
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/WonderlandEngine/plugins/pull/3. Required for `tools.openBrowser()`.